### PR TITLE
TASK: Fix typos in readme and comments, streamline language, add i18n…

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,11 +1,11 @@
 Unikka:
   Slick:
-    # include the theme css file form slick
+    # include the theme css file from slick
     theme: true
     backend:
       # disables autoplay in backend
       disableAutoplay: true
-    # breakpoints for the repsonsive tab
+    # breakpoints for the responsive tab
     responsive:
       sm: 576
       md: 768

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@
 
 # Slick Content Element for Neos CMS 
 
-This is a ready to use implementation of the Javascript package [slick](http://kenwheeler.github.io/slick/). 
+This is a ready-to-use implementation of the JavaScript package [slick](http://kenwheeler.github.io/slick/). 
 
 ## Installation
-Most of the time you have to make small adjustments to a package (e.g., the configuration in Settings.yaml). Because of that, it is important to add the corresponding package to the composer from your theme package. Mostly this is the site package located under Packages/Sites/. To install it correctly go to your theme package (e.g.Packages/Sites/Foo.Bar) and run following command:
+Most of the time you have to make small adjustments to a package (e.g., the configuration in Settings.yaml). Because of that, it is important to add the corresponding package to the composer manifest in your theme package. Mostly this is the site package located under `Packages/Sites/`. To install it correctly, go to your theme package (e.g. `Packages/Sites/Foo.Bar`) and run following command:
 
 ```bash
 composer require unikka/neos-slick --no-update
 ```
 
-The --no-update command prevent the automatic update of the dependencies. After the package was added to your theme composer.json, go back to the root of the Neos installation and run composer update. Your desired package is now installed correctly.
+The --no-update command prevents the automatic update of the dependencies. After the package was added to your theme `composer.json`, go back to the root of the Neos installation and run composer update. Your desired package is now installed correctly.
 
 ## Usage
-This package uses background images as slide.  If you want to use a fixed height for the slider you can use this as CSS:
+This package uses background images as slides. If you want to use a fixed height for the slider you can use the following CSS:
 
 ```css
 .slick-slide {
@@ -34,11 +34,12 @@ This package uses background images as slide.  If you want to use a fixed height
 }
 ```
 
-### Disabling / Enabling feature
-The Slide and the Slider element have a few mixins, which you can enable / disable to add / remove a feature.
+### Disabling / enabling features
+
+The Slide and the Slider element have a few mixins, which you can use to enable/disable and to add/remove a feature.
 
 #### Example 
-If you want to disbale the autoplay option in the backend, you can do this:
+If you want to disable the autoplay option in the backend, you can do this:
 
 ```yaml
 'Unikka.Slick:Content.Slider':
@@ -58,7 +59,7 @@ If you want to disbale the autoplay option in the backend, you can do this:
 | Unikka.Slick:Mixin.Fade            | false         | Fade                     |
 | Unikka.Slick:Mixin.Arrows          | true          | Arrows shown             |
 | Unikka.Slick:Mixin.Dots            | false         | Dots shown               |
-| Unikka.Slick:Mixin.SlidesToShow    | true          | Slide shown at once      |
+| Unikka.Slick:Mixin.SlidesToShow    | true          | Number of slides shown at once |
 | Unikka.Slick:Mixin.AdditionalClass | true          | Additional CSS-Class     |
 | Unikka.Slick:Mixin.Repsonsive.Sm   | true          | Responsive group mobile  |
 | Unikka.Slick:Mixin.Repsonsive.Md   | true          | Responsive group tablet  |
@@ -69,11 +70,11 @@ If you want to disbale the autoplay option in the backend, you can do this:
 
 | Mixin                                 | Default value | Description                |
 |---------------------------------------|---------------|----------------------------|
-| Unikka.Slick:Mixin.BackgroundImage | true          | Background iamge for Slide |
+| Unikka.Slick:Mixin.BackgroundImage | true          | Background image for Slide |
 | Unikka.Slick:Mixin.AdditionalClass | true          | Additional CSS-Class       |
 
 ### Fade option
-The fade options is disabled by default, because if you enable fade, the slides to show options isn't working. But you can simply enable it like this:
+The fade options is disabled by default, because if you enable fade, the "slides to show" option isn't working. But you can simply enable it like this:
 
 ```yaml
 'Unikka.Slick:Content.Slider':
@@ -87,12 +88,12 @@ The fade options is disabled by default, because if you enable fade, the slides 
 ```yaml
 Unikka:
   Slick:
-    # include the theme css file form slick
+    # include the theme css file from slick
     theme: true
     backend:
       # disables autoplay in backend
       disableAutoplay: true
-    # breakpoints for the repsonsive tab
+    # breakpoints for the responsive tab
     responsive:
       sm: 576px
       md: 768px
@@ -104,16 +105,16 @@ Unikka:
 ## Contribution
 
 We'd love you to contribute to neos-slick. We try to make it as easy as possible.
-We are using semantic-release to have more time to concentrate on important stuff
+We are using semantic versioning to have more time to concentrate on important stuff
 instead of struggling in the dependency or release hell.
 
 Therefore the first rule is to follow the [eslint commit message guideline](https://github.com/conventional-changelog-archived-repos/conventional-changelog-eslint/blob/master/convention.md).
-It is really easy, when you always commit via `yarn commit`. Commitizen will guide you.
+It is really easy if you always commit via `yarn commit`. Commitizen will guide you.
 
 All PRs will be merged into the master branch. Travis and semantic release will check the commit messages and start
 building a new release when the analysis of the latest commits will trigger that.
 
-If you have questions just ping us on twitter or github.
+If you have questions just ping us on Twitter or Github.
 
 ## About
 

--- a/Resources/Private/Translations/de/NodeTypes/Content/Slider.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/Slider.xlf
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="groups.slick-appearance">
                 <source>Appearance</source>
-                <target xml:lang="de">Aussehn</target>
+                <target xml:lang="de">Aussehen</target>
             </trans-unit>
             <trans-unit id="groups.slick-animation">
                 <source>Animation</source>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/AdditionalClass.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/AdditionalClass.xlf
@@ -3,7 +3,7 @@
     <file original="" product-name="Unikka.Slick" source-language="en" target-language="de" datatype="plaintext">
         <body>
             <trans-unit id="properties.additionalClass" xml:space="preserve">
-                <source>Additional Class (CSS)</source>
+                <source>Additional class (CSS)</source>
                 <target xml:lang="de">Zusätzliche Klasse (CSS)</target>
             </trans-unit>
         </body>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/Autoplay.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/Autoplay.xlf
@@ -8,7 +8,7 @@
 			</trans-unit>
             <trans-unit id="properties.autoplaySpeed" xml:space="preserve">
 				<source>Autoplay speed (ms)</source>
-                <target xml:lang="de">Wechsel Geschwindigkeit (ms)</target>
+                <target xml:lang="de">Wechselgeschwindigkeit (ms)</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/BackgroundImage.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/BackgroundImage.xlf
@@ -2,10 +2,10 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Unikka.Slick" source-language="en" target-language="de" datatype="plaintext">
         <body>
-            <trans-unit id="properties.pauseOnHover" xml:space="preserve">
-				<source>Pause on hover</source>
-                <target xml:lang="de">Pausieren, wenn Maus über dem Slider ist</target>
-			</trans-unit>
+            <trans-unit id="properties.backgroundImage" xml:space="preserve">
+                <source>Image</source>
+                <target xml:lang="de">Bild</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/Fade.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/Fade.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="properties.fade" xml:space="preserve">
 				<source>Fade Slides</source>
-                <target xml:lang="de">Slides verblassen</target>
+                <target xml:lang="de">Slides faden</target>
 			</trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/SlidesToScroll.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/SlidesToScroll.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="properties.slidesToScroll" xml:space="preserve">
                 <source>Slides to scroll</source>
-                <target xml:lang="de">Slides weiter rutschen</target>
+                <target xml:lang="de">Slides weiter scrollen</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/SlidesToShow.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/SlidesToShow.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="properties.slidesToShow" xml:space="preserve">
                 <source>Slides to show</source>
-                <target xml:lang="de">Slides die angezeigt werden</target>
+                <target xml:lang="de">Slides, die angezeigt werden</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/en/NodeTypes/Mixin/AdditionalClass.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Mixin/AdditionalClass.xlf
@@ -3,7 +3,7 @@
     <file original="" product-name="Unikka.Slick" source-language="en" datatype="plaintext">
         <body>
             <trans-unit id="properties.additionalClass" xml:space="preserve">
-                <source>Additional Class (CSS)</source>
+                <source>Additional class (CSS)</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Translations/en/NodeTypes/Mixin/BackgroundImage.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Mixin/BackgroundImage.xlf
@@ -2,10 +2,9 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
     <file original="" product-name="Unikka.Slick" source-language="en" target-language="de" datatype="plaintext">
         <body>
-            <trans-unit id="properties.pauseOnHover" xml:space="preserve">
-				<source>Pause on hover</source>
-                <target xml:lang="de">Pausieren, wenn Maus über dem Slider ist</target>
-			</trans-unit>
+            <trans-unit id="properties.backgroundImage" xml:space="preserve">
+                <source>Image</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Mixin/Fade.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Mixin/Fade.xlf
@@ -3,7 +3,7 @@
     <file original="" product-name="Unikka.Slick" source-language="en" datatype="plaintext">
         <body>
             <trans-unit id="properties.fade" xml:space="preserve">
-				<source>Fade Slides</source>
+				<source>Fade slides</source>
 			</trans-unit>
         </body>
     </file>


### PR DESCRIPTION
… files for BackgroundImage mixin

Some of the German language like "erblassen" for fade or "rutschen" for scroll might be technically correct, but is very German and IMO not common.

Fixes: #39 