### PR TITLE
Fix: Avoid exception ImageVariant could not be converted to string

### DIFF
--- a/Resources/Private/Fusion/Slide.fusion
+++ b/Resources/Private/Fusion/Slide.fusion
@@ -1,7 +1,6 @@
 prototype(Unikka.Slick:Content.Slide) < prototype(Neos.Fusion:Component) {
-    backgroundImage = ${ q(node).property('backgroundImage') }
-    backgroundImage.@process.convertToUri = Neos.Neos:ImageUri {
-        asset = ${ value }
+    backgroundImage = Neos.Neos:ImageUri {
+        asset = ${ q(node).property('backgroundImage') }
     }
 
     classNames = Neos.Fusion:RawArray {


### PR DESCRIPTION
Avoids an exception by removing the processor and do the conversion directly