### PR TITLE
New: Use flat content structure in slides

### DIFF
--- a/Classes/ContentRepository/Transformations/FlatSlideStructureTransformation.php
+++ b/Classes/ContentRepository/Transformations/FlatSlideStructureTransformation.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Unikka\Slick\ContentRepository\Transformations;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Domain\Model\NodeData;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Migration\Transformations\AbstractTransformation;
+use Neos\Neos\Controller\CreateContentContextTrait;
+
+/**
+ * Move content of slide content collections to the slide
+ */
+class FlatSlideStructureTransformation extends AbstractTransformation
+{
+    use CreateContentContextTrait;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @Flow\Inject
+     * @var \Neos\ContentRepository\Domain\Service\ContextFactoryInterface
+     */
+    protected $contextFactory;
+
+    /**
+     * @param NodeData $node
+     * @return boolean
+     */
+    public function isTransformable(NodeData $node)
+    {
+        $numberOfChildNodes = $node->getNumberOfChildNodes('Neos.Neos:ContentCollection', $node->getWorkspace(), $node->getDimensions());
+        return ($numberOfChildNodes > 0);
+    }
+
+    /**
+     * @param NodeData $node
+     * @return void
+     * @throws \Neos\Eel\Exception
+     */
+    public function execute(NodeData $node)
+    {
+        $contentContext = $this->createContentContext('live', []);
+        $slideNode = $contentContext->getNodeByIdentifier($node->getIdentifier());
+
+        /** @var NodeInterface $contentCollection */
+        $contentCollections = $slideNode->getChildNodes('Neos.Neos:ContentCollection');
+
+        foreach ($contentCollections as $contentCollection) {
+            if ($contentCollection->hasChildNodes()) {
+                $this->moveChildNodesToSlide($contentCollection->getChildNodes(), $slideNode);
+            }
+
+            $contentCollection->setHidden(true);
+        }
+    }
+
+    protected function moveChildNodesToSlide($children, NodeInterface $slide) {
+        foreach ($children as $childNode) {
+            /** @var NodeInterface $childNode */
+            $childNode->moveInto($slide);
+        }
+    }
+}

--- a/Classes/ContentRepository/Transformations/RemoveEmptyCollectionsTransformation.php
+++ b/Classes/ContentRepository/Transformations/RemoveEmptyCollectionsTransformation.php
@@ -8,9 +8,9 @@ use Neos\ContentRepository\Migration\Transformations\AbstractTransformation;
 use Neos\Neos\Controller\CreateContentContextTrait;
 
 /**
- * Move content of slide content collections to the slide
+ * Remove empty content collections of the slide
  */
-class FlatSlideStructureTransformation extends AbstractTransformation
+class RemoveEmptyCollectionsTransformation extends AbstractTransformation
 {
     use CreateContentContextTrait;
 
@@ -36,21 +36,8 @@ class FlatSlideStructureTransformation extends AbstractTransformation
 
         foreach ($contentCollections as $contentCollection) {
             /** @var NodeInterface $contentCollection */
-            if ($contentCollection->hasChildNodes()) {
-                $this->moveChildNodesToSlide($contentCollection->getChildNodes(), $slideNode);
-            }
-        }
-    }
-
-    /**
-     * @param array $children
-     * @param NodeInterface $slide
-     */
-    protected function moveChildNodesToSlide(array $children, NodeInterface $slide) {
-        foreach ($children as $childNode) {
-            if ($childNode instanceof NodeInterface) {
-                /** @var NodeInterface $childNode */
-                $childNode->moveInto($slide);
+            if ($contentCollection->hasChildNodes() === false) {
+                $contentCollection->remove();
             }
         }
     }

--- a/Configuration/NodeTypes.Content.Slide.yaml
+++ b/Configuration/NodeTypes.Content.Slide.yaml
@@ -5,13 +5,11 @@
     'Unikka.Slick:Mixin.ContentBackground': true
     'Unikka.Slick:Mixin.LazyLoading': true
     'Unikka.Slick:Mixin.AdditionalClass': true
-  childNodes:
-    'content':
-      type: 'Neos.Neos:ContentCollection'
-      constraints:
-      nodeTypes:
-        'Unikka.Slick:Content.Slider': false
-        'Unikka.Slick:Content.Slide': false
+    'Neos.Neos:ContentCollection': true
+  constraints:
+    nodeTypes:
+      'Unikka.Slick:Content.Slider': false
+      'Unikka.Slick:Content.Slide': false
 
   ui:
     label: 'Slide'

--- a/Migrations/TYPO3CR/Version20200225141414.yaml
+++ b/Migrations/TYPO3CR/Version20200225141414.yaml
@@ -1,0 +1,16 @@
+up:
+  comments: 'Migrate content collection of slides to a flat structure'
+  migration:
+    -
+      filters:
+        -
+          type: 'NodeType'
+          settings:
+            nodeType: 'Unikka.Slick:Content.Slide'
+            withSubTypes: false
+      transformations:
+        -
+          type: 'Unikka\Slick\ContentRepository\Transformations\FlatSlideStructureTransformation'
+          settings: []
+down:
+  comments: 'No down migration available'

--- a/Migrations/TYPO3CR/Version20200225141420.yaml
+++ b/Migrations/TYPO3CR/Version20200225141420.yaml
@@ -1,5 +1,5 @@
 up:
-  comments: 'Migrate content collection of slides to a flat structure'
+  comments: 'Remove empty content collection of slides'
   migration:
     -
       filters:
@@ -9,7 +9,7 @@ up:
             nodeType: 'Unikka.Slick:Content.Slide'
       transformations:
         -
-          type: 'Unikka\Slick\ContentRepository\Transformations\FlatSlideStructureTransformation'
+          type: 'Unikka\Slick\ContentRepository\Transformations\RemoveEmptyCollectionsTransformation'
           settings: []
 down:
   comments: 'No down migration available'

--- a/Resources/Private/Fusion/Components/SlideContent.fusion
+++ b/Resources/Private/Fusion/Components/SlideContent.fusion
@@ -6,9 +6,7 @@ prototype(Unikka.Slick:Components.SlideContent) < prototype(Neos.Neos:ContentCom
     }
     additionalStyles.@if.hasBackground = ${ props.backgroundImage }
 
-    content = Neos.Neos:ContentCollection {
-        nodePath = 'content'
-    }
+    content = Neos.Neos:ContentCollectionRenderer
 
     innerContentClassNames = Neos.Fusion:RawArray {
         class = 'slide__inner__content'


### PR DESCRIPTION
We get rid of the additional content collection in the slides.
Thanks to @andrehoffmann30 for providing the initial change.

I just added node migrations for people that already had the new structure.